### PR TITLE
Use LAPACK.getrf! to calculate dlr in matfreq. We find that the opera…

### DIFF
--- a/src/correlator/basis.jl
+++ b/src/correlator/basis.jl
@@ -91,7 +91,7 @@ function matfreq2dlr(type, green, dlrGrid, β=1.0; axis=1, rtol=1e-12)
     ωGrid = dlrGrid[:ω]
     # kernel = kernelΩ(type, nGrid, ωGrid, β) / β 
     kernel = kernelΩ(type, nGrid, ωGrid, β)
-    # kernel, ipiv, info = LAPACK.cgetrf!(Complex{Float64}.(kernel)) # LU factorization
+    kernel, ipiv, info = LAPACK.getrf!(Complex{Float64}.(kernel)) # LU factorization
 
     if axis == 1
         g = copy(green)
@@ -99,8 +99,8 @@ function matfreq2dlr(type, green, dlrGrid, β=1.0; axis=1, rtol=1e-12)
         g = permutedims(green, [axis, 1])
     end
 
-    # coeff = LAPACK.cgetrs!('N', kernel, ipiv, g) # LU linear solvor for green=kernel*coeff
-    coeff = kernel \ g # solve green=kernel*coeff
+    coeff = LAPACK.getrs!('N', kernel, ipiv, g) # LU linear solvor for green=kernel*coeff
+    # coeff = kernel \ g # solve green=kernel*coeff
 
     if axis == 1
         return coeff


### PR DESCRIPTION
…tor \ is not as universal as getrf