### PR TITLE
fix typos in md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ julia> using Pkg; Pkg.add(PackageSpec(url="https://github.com/kunyuan/QuantumSta
 
 ## Development
 
-1. To develop or modify this package, you need to install this package first, then run from the Julia REPL:
+1. To develop or modify this package, you need to install this package first, then type `]` to enter the Pkg REPL mode and run:
 ```julia
 pkg> dev QuantumStatistics
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ julia> using Pkg; Pkg.add(PackageSpec(url="https://github.com/kunyuan/QuantumSta
 
 1. To develop or modify this package, you need to install this package first, then run from the Julia REPL:
 ```julia
-julia> dev QuantumStatistics
+pkg> dev QuantumStatistics
 ```
 This command will automatically create a copy of the package git repository in at ~/.julia/dev/QuantumStatistics.
 

--- a/docs/src/man/important_sampling.md
+++ b/docs/src/man/important_sampling.md
@@ -21,7 +21,7 @@ F_{\rm MC} =\frac{1}{N} \left[ \sum_{i=1}^{N_f} \frac{f(x_i)}{\rho_f(x_i)} + \su
 ```math
 G_{\rm MC} =\frac{1}{N} \left[\sum_{i=1}^{N_f} 0 + \sum_{i=1}^{N_g} \frac{g(x_i)}{\rho_g(x_i)}  \right]
 ```
-  
+
 The probability density of a given configuration is proportional to $\rho_{f}(x)=|f(x)|$ and $\rho_{g}(x)=|g(x)|$, respectively. After $N$ MC updates, the physical sector is sampled for $N_f$ times, and the normalization sector is for $N_g$ times. 
 
 Now we estimate the statistic error. According to the propagation of uncertainty, the variance of $F$  is given by
@@ -44,7 +44,7 @@ Similarly, the variance of $G_{\rm MC}$ can be written as
 ```math
 \sigma^2_{G_{\rm MC}}=  \int \frac{g^2(x)}{\rho_g(x)} \frac{{\rm d}{x}}{Z} - \frac{G^2}{Z^2}
 ```
- 
+
 By substituting $\rho_{f}(x)=|f(x)|$ and  $\rho_{g}(x)=|g(x)|$, the variances of $F_{\rm MC}$ and $G_{\rm MC}$ are given by
 ```math
 \sigma^2_{F_{\rm MC}}= \frac{1}{Z^2} \left( Z Z_f - F^2 \right)
@@ -58,8 +58,8 @@ We derive the variance of $F$ as
 ```
 Note that $g(x)>0$ indicates $Z_g = G$,  so that
 ```math
-\frac{\sigma^2_F}{F^2} = \frac{Z_f^2}{F^2}+\frac{G\cdot Z_f}{F^2}+\frac{Zf}{G} - 1
-``` 
+\frac{\sigma^2_F}{F^2} = \frac{Z_f^2}{F^2}+\frac{G\cdot Z_f}{F^2}+\frac{Z_f}{G} - 1
+```
 Interestingly, this variance is a function of $G$ instead of a functional of $g(x)$. It is then possible to normalized $g(x)$ with a constant to minimize the variance. The optimal constant makes $G$ to be,
 ```math
 \frac{d \sigma^2_F}{dG}=0,
@@ -70,7 +70,7 @@ which makes $G_{best} = |F|$. The minimized the variance is given by,
 ```
 The equal sign is achieved when $f(x)>0$ is positively defined.
 
-**It is very important to that the above analysis is based on an assumption that the autocorrelation time negligible. The autocorrelation time related to the jump between the normalization and physical sectors is controlled by the deviation of the ratio $|f(x)|/g(x)$ from unity. The variance $\sigma_F^2$ given above will be amplified to $\sim \sigma_F^2 \tau$ where $\tau$ is the autocorrelation time.**
+**It is very important that the above analysis is based on the assumption that the autocorrelation time negligible. The autocorrelation time related to the jump between the normalization and physical sectors is controlled by the deviation of the ratio $|f(x)|/g(x)$ from unity. The variance $\sigma_F^2$ given above will be amplified to $\sim \sigma_F^2 \tau$ where $\tau$ is the autocorrelation time.**
 
 ## Approach 2: Conventional algorithm (e.g., Vegas algorithm)
 
@@ -81,7 +81,7 @@ Important sampling is actually more straightforward than the above approach. One
 
 the variance of $F$ in this approach is given by,
 ```math
-\frac{\sigma_F^2}{F^2}=\frac{1}{F^2}\int dx \left( \frac{f(x)}{g(x)}- \frac{F}{Z_g}\right)^2\rho_g(x)
+\sigma_F^2=Z_g^2\int dx \left( \frac{f(x)}{g(x)}- \frac{F}{Z_g}\right)^2\rho_g(x)
 ```
 ```math
 \frac{\sigma_F^2}{F^2}=\frac{Z_g}{F^2}\int dx \frac{|f(x)|^2}{|g(x)|}- 1
@@ -93,7 +93,7 @@ The optimal $g(x)$ that minimizes the variance is $g(x) =|f(x)|$,
 
 - The variance of the conventional approach is a functional of $g(x)$, while that of the previous approach isn't. There are two interesting limit:
 - If the $f(x)>0$, the optimal choice $g(x)=|f(x)|$ leads to zero variance. In this limit, the conventional approach is clearly much better than the previous approach.
-- On the other hand, if $g(x)$ is far from the optimal choice $|f(x)|$, say simply setting $g(x)=1$, one naively expect that the the conventional approach may leads to much larger variance than the previous approach. **However,  this statement may not be true. If $g(x)$ is very different from $f(x)$, the normalization and the physical sector in the previous approach mismatch, causing large autocorrelation time and large statistical error . In contrary, the conventional approach doesn't have this problem.**
+- On the other hand, if $g(x)$ is far from the optimal choice $|f(x)|$, say simply setting $g(x)=1$, one naively expect that the the conventional approach may leads to much larger variance than the previous approach. **However,  this statement may not be true. If $g(x)$ is very different from $f(x)$, the normalization and the physical sector in the previous approach mismatch, causing large autocorrelation time and large statistical error . In contrast, the conventional approach doesn't have this problem.**
 
 ## Benchmark
 - To benchmark, we sample the following integral up to $10^8$ updates, 
@@ -101,7 +101,7 @@ The optimal $g(x)$ that minimizes the variance is $g(x) =|f(x)|$,
 \int_0^\beta e^{-(x-\beta/2)^2/\delta^2}dx \approx \sqrt{\pi}\delta
 ```
 where $\beta \gg \delta$.
-1. ``g(x)=|F(x)|``:
+1. ``g(x)=|f(x)|``
 - __Normalization Sector__:  __doesn't__ lead to exact result, the variance $\left(\frac{Z_f}{F}+1\right)^2 - 2=2$ doesn't change with parameters
 
 | $\beta$ | 10        | 100       |
@@ -109,24 +109,22 @@ where $\beta \gg \delta$.
 | result  | 0.1771(1) | 0.1773(1) |
 
 - __Conventional__: exact result
-2. ``g(x)=1``
-	
+2. ``g(x)=\sqrt{\pi}\delta/\beta``
 | $\beta$       | 10        | 100        |
 | ------------- | --------- | ---------- |
 | Normalization | 0.1772(4) | 0.1767(17) |
 | Conventional  | 0.1777(3) | 0.1767(8)  |
-	
-3. ``g(x)=exp(-(x-\beta/2+s)/\delta^2)`` with ``\beta=100``
-	
+
+3. ``g(x)=exp(-(x-\beta/2+s)^2/\delta^2)`` with ``\beta=100``
 | $s$           | $\delta$  | $2\delta$  | $3\delta$   | $4\delta$   | $5\delta$ |
 | ------------- | --------- | ---------- | ----------- | ----------- | --------- |
 | Normalization | 0.1775(8) | 0.1767(25) | 0.1770(60)  | 0.176(15)   | 183(143)  |
 | Conventional  | 0.1776(5) | 0.1707(39) | 0.1243(174) | 0.0204 (64) |
-	
-The conventional algorithm is not egordic anymore for $s=4\delta$, the acceptance ratio to update $x$ is about $0.15%$, while the normalization algorithm becomes non egordic for $s=5\delta$. So the latter is slightly more stable.
+
+The conventional algorithm is not ergodic anymore for $s=4\delta$, the acceptance ratio to update $x$ is about $0.15%$, while the normalization algorithm becomes non ergodic for $s=5\delta$. So the latter is slightly more stable.
 
 <!-- The code are ![[test.jl]] for the normalization approach and ![[test2.jl]] for the conventional approach. -->
 
-
 **Reference**: 
 [1] Wang, B.Z., Hou, P.C., Deng, Y., Haule, K. and Chen, K., Fermionic sign structure of high-order Feynman diagrams in a many-fermion system. Physical Review B, 103, 115141 (2021).
+


### PR DESCRIPTION
1. fix typos in the note on important sampling
2. fix a typo in README.md